### PR TITLE
Add ddev version constraint.

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -88,7 +88,7 @@ global_files:
 # See https://github.com/Masterminds/semver#checking-version-constraints for constraint rules.
 # Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
 # example: ddev_version_constraint: '>= v1.23.4'
-ddev_version_constraint: ''
+ddev_version_constraint: '>= 1.23.5'
 
 # List of add-on names that this add-on depends on
 dependencies:


### PR DESCRIPTION
The `ddev dotenv` command that we're using was only introduced with ddev 1.23.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the add-on’s system requirement: users now need DDEV version 1.23.5 or higher. This ensures smoother compatibility and a more reliable experience during installation and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->